### PR TITLE
Use Allow dotnet to use Preformatted JSON

### DIFF
--- a/src/destination/loggly.rs
+++ b/src/destination/loggly.rs
@@ -24,8 +24,7 @@ impl Destination for Loggly {
 
         let payload = logs
             .into_iter()
-            .map(|log| serde_json::to_string(&log))
-            .flatten()
+            .map(|log| log.to_string())
             .collect::<Vec<String>>()
             .join("\n");
 

--- a/src/extension/log.rs
+++ b/src/extension/log.rs
@@ -77,6 +77,7 @@ pub fn subscribe(config: &LogSubscriptionConfig,client: &Client, ext_id: &Extens
         .unwrap();
 }
 
+
 #[derive(Default, Debug, Deserialize, Clone)]
 pub struct CloudWatchLog {
     pub time: String,

--- a/src/parser/dotnet.rs
+++ b/src/parser/dotnet.rs
@@ -1,53 +1,20 @@
-use super::StructuredLog;
+use super::Log;
 use crate::log::CloudWatchLog;
-use anyhow::Result;
-use serde::Deserialize;
-use std::convert::TryFrom;
 
-#[derive(Debug, Deserialize)]
-struct DotnetCloudFormationLog {
-    timestamp: String,
-    data: serde_json::Value,
-}
-
-impl TryFrom<&CloudWatchLog> for DotnetCloudFormationLog {
-    type Error = ();
-    fn try_from(log: &CloudWatchLog) -> Result<Self, Self::Error> {
-        match &log.record {
-            serde_json::Value::String(record) => match serde_json::from_str(&record) {
-                Ok(data) => Ok(DotnetCloudFormationLog {
-                    timestamp: log.time.clone(),
-                    data,
-                }),
-                Err(_) => Err(()),
-            },
-            _ => Err(()),
-        }
-    }
-}
-
-impl Into<StructuredLog> for DotnetCloudFormationLog {
-    fn into(self) -> StructuredLog {
-        StructuredLog {
-            timestamp: Some(self.timestamp),
-            guid: None,
-            level: None,
-            data: self.data,
-        }
-    }
-}
-
-pub fn parse(log: &CloudWatchLog) -> Option<StructuredLog> {
-    let log: Result<DotnetCloudFormationLog, _> = DotnetCloudFormationLog::try_from(log);
-    match log {
-        Ok(l) => Some(l.into()),
-        Err(_) => None,
+pub fn parse(log: &CloudWatchLog) -> Option<Log> {
+    match &log.record {
+        serde_json::Value::String(record) => match serde_json::from_str(&record) {
+            Ok(data) => Some(Log::Preformatted(data)),
+            Err(_) => None,
+        },
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::super::Log;
     use super::parse;
     use super::CloudWatchLog;
 
@@ -55,7 +22,7 @@ mod tests {
     fn test_parse_dotnet() {
         let input = CloudWatchLog {
             record: serde_json::Value::String(
-                "{ \"statusCode\": 200, \"body\": \"DotNet\" }".to_string(),
+                "{ \"statusCode\": 200, \"body\": \"DotNet\", \"level\": \"info\"  }".to_string(),
             ),
             time: "2020-11-18T23:52:30.128Z".to_string(),
             ..Default::default()
@@ -63,17 +30,14 @@ mod tests {
         let output = parse(&input);
 
         assert_eq!(output.is_some(), true);
-        let output_unwrapped = output.unwrap();
-
-        println!("{:?}", output_unwrapped);
-
-        assert_eq!(
-            output_unwrapped.timestamp.unwrap(),
-            "2020-11-18T23:52:30.128Z"
-        );
-        assert_eq!(output_unwrapped.guid, None);
-        assert_eq!(output_unwrapped.level, None);
-        assert_eq!(output_unwrapped.data["statusCode"], 200);
-        assert_eq!(output_unwrapped.data["body"], "DotNet");
+        match output.unwrap() {
+            Log::Preformatted(log) => {
+                assert_eq!(log["statusCode"], 200);
+                assert_eq!(log["body"], "DotNet");
+            }
+            _ => {
+                panic!("Expected Preformatted log");
+            }
+        }
     }
 }


### PR DESCRIPTION
Dotnet Lambdas now use their own preformatted JSON.
"Info" -> "INFO"
"Warn" -> "WARN"
"Error" -> "ERROR"
