### PR TITLE
Fix loggly payload exceeding 5mb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
+name = "byte_chunk"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d806769adb1fdd952ca677aea6b3a6243e5f08a02e96e78b1aa671a81b787c"
+dependencies = [
+ "bytes 1.0.1",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +133,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -419,7 +434,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -447,7 +462,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "headers-core",
  "http",
  "mime",
@@ -479,7 +494,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -490,7 +505,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -518,7 +533,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -542,7 +557,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
  "tokio",
@@ -576,7 +591,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -1152,7 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1449,7 +1464,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -1502,7 +1517,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -1561,7 +1576,7 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",
@@ -1684,7 +1699,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "headers",
  "http",
@@ -1864,6 +1879,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "byte_chunk",
  "cfg-if 1.0.0",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4.13"
 env_logger = "0.8.2"
 async-trait = "0.1.42"
 cfg-if = "1.0.0"
+byte_chunk = "0.1.0"
 
 [features]
 local = []

--- a/src/handler/loggly.rs
+++ b/src/handler/loggly.rs
@@ -60,8 +60,9 @@ impl LogHandler for Loggly {
 
         let chunks = stringified_logs.byte_chunks_safe_mut(4900000); //give ourselves 100kb overhead to be safe.
 
-        for chunk in chunks {
+        for (index, chunk) in chunks.enumerate() {
             self.send_logs(chunk).await?;
+            log::debug!("Sent Chunk {} of {} items.", index, chunk.len());
         }
 
         Ok(())

--- a/src/handler/loggly.rs
+++ b/src/handler/loggly.rs
@@ -3,6 +3,7 @@ use crate::models::RawCloudWatchLog;
 use crate::parser::Parser;
 use anyhow::{ensure, Error, Result};
 use async_trait::async_trait;
+use byte_chunk::SafeByteChunkedMut;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use std::time::Duration;
@@ -18,18 +19,9 @@ impl Loggly {
     pub fn builder() -> LogglyBuilder {
         LogglyBuilder::new()
     }
-}
 
-#[async_trait]
-impl LogHandler for Loggly {
-    async fn handle_logs(&self, cloudwatch_logs: Vec<RawCloudWatchLog>) -> Result<()> {
-        let logs = self.parser.parse(cloudwatch_logs);
-
-        let payload: String = logs
-            .iter()
-            .map(|log| log.to_string())
-            .collect::<Vec<String>>()
-            .join("\n");
+    async fn send_logs(&self, logs: &[String]) -> Result<()> {
+        let payload: String = logs.join("\n");
 
         log::debug!(
             "Sending {} logs to Loggly, payload length: {}",
@@ -51,6 +43,26 @@ impl LogHandler for Loggly {
             res.status() == reqwest::StatusCode::OK,
             "Error Sending Logs"
         );
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LogHandler for Loggly {
+    async fn handle_logs(&self, cloudwatch_logs: Vec<RawCloudWatchLog>) -> Result<()> {
+        let logs = self.parser.parse(cloudwatch_logs);
+
+        let mut stringified_logs = logs
+            .iter()
+            .map(|log| log.to_string())
+            .collect::<Vec<String>>();
+
+        let chunks = stringified_logs.byte_chunks_safe_mut(4900000); //give ourselves 100kb overhead to be safe.
+
+        for chunk in chunks {
+            self.send_logs(chunk).await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Under high load on a chatty lambda, logs can buffer up to 5mb. To fix this we need to chunk the logs to a total size of less that 5MB (_loggly's max payload size for /bulk endpoint_). Logs that exceed 5mb on their own will be culled.